### PR TITLE
Livequery placeholders

### DIFF
--- a/examples/CompleteTrade.gql
+++ b/examples/CompleteTrade.gql
@@ -1,0 +1,7 @@
+mutation CompleteTrade($identityId: Int!, $tradeId: String!) {
+  result: CreateEnjinRequest(identity_id: $identityId, type: COMPLETE_TRADE, complete_trade_data: { trade_id: $tradeId }) {
+    id
+    encoded_data
+    state
+  }
+}

--- a/examples/CreateTrade.gql
+++ b/examples/CreateTrade.gql
@@ -1,0 +1,7 @@
+mutation CreateTrade($identityId: Int!, $askingTokenId: String!, $askingValue: Int!, $offeringTokenId: String!, $offeringValue: Int!, $secondPartyIdentityId: Int!) {
+  result: CreateEnjinRequest(identity_id: $identityId, type: CREATE_TRADE, create_trade_data: { asking_tokens: [{ id: $askingTokenId, value: $askingValue }], offering_tokens: [{ id: $offeringTokenId, value: $offeringValue }], second_party_identity_id: $secondPartyIdentityId }) {
+    id
+    encoded_data
+    state
+  }
+}

--- a/examples/CreateUser.gql
+++ b/examples/CreateUser.gql
@@ -1,0 +1,32 @@
+mutation CreateUser($name: String!, $password: String!, $email: String!, $role: String!) {
+  user: CreateEnjinUser(name: $name, password: $password, email: $email, role: $role) {
+    id
+    name
+    email
+    roles {
+      id
+      name
+      permissions {
+        id
+        name
+      }
+    }
+    identities {
+      id
+      ethereum_address
+      linking_code
+      updated_at
+      created_at
+      fields {
+        key
+        value
+        searchable
+        displayable
+        unique
+      }
+    }
+    access_tokens
+    created_at
+    updated_at
+  }
+}

--- a/examples/Items.gql
+++ b/examples/Items.gql
@@ -1,0 +1,27 @@
+query Items($identityId: Int!) {
+  result: EnjinIdentities(id: $identityId) {
+    tokens(include_creator_tokens: true) {
+        app_id
+        index
+        token_id
+        name
+        creator
+        totalSupply
+        reserve
+        circulatingSupply
+        supplyModel
+        meltValue
+        meltFeeRatio
+        meltFeeMaxRatio
+        transferable
+        transferFeeSettings {
+          type
+          token_id
+          value
+        }
+        nonFungible
+        icon
+        isCreator
+    }
+  }
+}

--- a/examples/Login.gql
+++ b/examples/Login.gql
@@ -1,0 +1,14 @@
+query Login($email:String!, $password:String!) {
+  results: EnjinOauth(email: $email, password: $password) {
+    id
+    access_tokens
+    roles {
+      name
+    }
+    identities {
+      id
+      app_id
+      ethereum_address
+    }
+  }
+}

--- a/examples/MeltToken.gql
+++ b/examples/MeltToken.gql
@@ -1,0 +1,7 @@
+mutation MeltToken($identityId: Int!, $tokenId: String!, $value: Int!) {
+  request: CreateEnjinRequest(type: MELT, identity_id: $identityId, melt_token_data: { token_id: $tokenId, value: $value }) {
+    id
+    encoded_data
+    state
+  }
+}

--- a/examples/SendItem.gql
+++ b/examples/SendItem.gql
@@ -1,0 +1,7 @@
+mutation SendItem($identityId: Int!, $recipientIdentityId: Int!, $tokenId: String!, $value: Int!) {
+  CreateEnjinRequest(type: SEND, identity_id: $identityId, send_token_data: { recipient_identity_id: $recipientIdentityId, token_id: $tokenId, value: $value }) {
+    id
+    encoded_data
+    state
+  }
+}

--- a/ko/live_query/snippets/access_credentials.html
+++ b/ko/live_query/snippets/access_credentials.html
@@ -18,40 +18,7 @@
                 클라우드 플랫폼에 로그인 하기 위해서는 이메일 주소와 암호가 필요합니다. 이를 실행하기 위한 GraphQL 쿼리는 다음과 같습니다:
             </p>
 
-            <pre><code class="query-display language-graphql">query login($email:String!, $password:String!) {
-  results: EnjinOauth(email: $email, password: $password) {
-    id
-    access_tokens
-    roles {
-      name
-    }
-    identities {
-      id
-      app_id
-      ethereum_address
-    }
-  }
-}</code></pre>
-
-            <p>
-                ‘Submit Query’ 버튼을 누르면 위에 있는 쿼리가 아래에 추가된 파라미터와 함께 클라우드 플랫폼 엔드 포인트에 POST됩니다:
-            </p>
-
-            <form method="post">
-                <input class="parameter" type="text" name="email" placeholder="Email">
-                <br>
-                <input class="parameter" type="text" name="password" placeholder="Password">
-
-                <pre><code class="parameter-display language-json">{}</code></pre>
-
-                <button class="v-btn primary" type="submit">Submit Query</button>
-            </form>
-
-            <p>
-                다음은 클라우드 플랫폼에 출력된 응답입니다:
-            </p>
-
-            <pre><code class="output-display language-json">{}</code></pre>
+            {{ LoginExample }}
 
             <p>
                 Unity SDK에서는 <a

--- a/ko/live_query/snippets/creating_a_new_user.html
+++ b/ko/live_query/snippets/creating_a_new_user.html
@@ -25,64 +25,7 @@
             이 값은 사용할 앱 ID 입니다. “액세스 자격 증명 얻기” 호출에 대한 응답으로 받은 “app_id” 필드에서 잠재적 App 식별자를 찾을 수 있습니다.
             </p>
 
-            <!--input id="appId" type="text" name="appId" placeholder="App ID"-->
-
-            <pre><code class="query-display language-graphql">mutation createUser($name: String!, $password: String!, $email: String!, $role: String!) {
-  user: CreateEnjinUser(name: $name, password: $password, email: $email, role: $role) {
-    id
-    name
-    email
-    roles {
-      id
-      name
-      permissions {
-        id
-        name
-      }
-    }
-    identities {
-      id
-      ethereum_address
-      linking_code
-      updated_at
-      created_at
-      fields {
-        key
-        value
-        searchable
-        displayable
-        unique
-      }
-    }
-    access_tokens
-    created_at
-    updated_at
-  }
-}</code></pre>
-
-            <p>
-                ‘Submit Query’ 버튼을 누르면 위에 있는 쿼리가 아래에 추가된 파라미터와 함께 클라우드 플랫폼 엔드 포인트에 POST됩니다:
-            </p>
-
-            <form method="post">
-                <input class="parameter" type="text" name="name" placeholder="Name">
-                <br>
-                <input class="parameter" type="text" name="password" placeholder="Password">
-                <br>
-                <input class="parameter" type="text" name="email" placeholder="Email">
-                <br>
-                <input class="parameter" type="text" name="role" placeholder="Role" value="Player">
-
-                <pre><code class="parameter-display language-json">{}</code></pre>
-
-                <button class="v-btn primary" type="submit">Submit Query</button>
-            </form>
-
-            <p>
-                다음은 클라우드 플랫폼에 출력된 응답입니다:
-            </p>
-
-            <pre><code class="output-display language-json">{}</code></pre>
+            {{ CreateUserExample }}
 
             <p>
                 이 예제 쿼리에서 클라우드 플랫폼에 새로운 사용자를 생성했습니다. 이 콜이 성공하려면 호출자가 자신의 앱에서 사용자를 생성할 수 있는 권한이 있어야 합니다.

--- a/ko/live_query/snippets/getting_a_users_items.html
+++ b/ko/live_query/snippets/getting_a_users_items.html
@@ -18,51 +18,7 @@
                 클라우드 플랫폼에서 사용자의 인벤토리를 검색하려면 사용자의 ID를 알아야 합니다. 이를 위한 GraphQL 쿼리는 다음과 같습니다:
             </p>
 
-            <pre><code class="query-display language-graphql">query getAllItems($identityId: Int!) {
-  result: EnjinIdentities(id: $identityId) {
-    tokens(include_creator_tokens: true) {
-        app_id
-        index
-        token_id
-        name
-        creator
-        totalSupply
-        reserve
-        circulatingSupply
-        supplyModel
-        meltValue
-        meltFeeRatio
-        meltFeeMaxRatio
-        transferable
-        transferFeeSettings {
-          type
-          token_id
-          value
-        }
-        nonFungible
-        icon
-        isCreator
-    }
-  }
-}</code></pre>
-
-            <p>
-                ‘Submit Query’ 버튼을 누르면 위에 있는 쿼리가 아래에 추가된 파라미터와 함께 클라우드 플랫폼 엔드 포인트에 POST됩니다:
-            </p>
-
-            <form method="post">
-                <input class="parameter" type="text" name="identityId" placeholder="Identity ID">
-
-                <pre><code class="parameter-display language-json">{}</code></pre>
-
-                <button class="v-btn primary" type="submit">Submit Query</button>
-            </form>
-
-            <p>
-                다음은 클라우드 플랫폼에 출력된 응답입니다:
-            </p>
-
-            <pre><code class="output-display language-json">{}</code></pre>
+            {{ ItemsExample }}
 
             <p>
                 이 예제 쿼리에서는 클라우드 플랫폼에서 사용자 인벤토리의 첫페이지를 검색했습니다. 게임의 필요에 따라 추가 아이템을 쿼리하도록 ‘페이지’ 매개변수를 변경할 수 있습니다.

--- a/ko/live_query/snippets/linking_a_wallet.html
+++ b/ko/live_query/snippets/linking_a_wallet.html
@@ -7,101 +7,21 @@
     새로 생성된 ID에는 코드가 포함되어 있는데, 플레이어는 이 코드를 엔진 지갑에 입력하여 이더리움 지갑에 연결할 수 있습니다. 이는 아이템들을 처리하기 위해 이용됩니다.
   </summary>
   <div>
-                      <!--
-            <p>
-              이 방법은 관리자의 액세스 토큰에 지정된 세부 정보로 새 사용자 및 ID를 생성하는 요청을 클라우드 플랫폼으로 보냅니다. 이 ID는 특정 시점에 엔진지갑 앱을 사용하여 플레이어의 지갑에 연결해야 합니다. 이러한 유형의 사용자 생성은 게임 게발자가 클라우드 플랫폼을 일종의 인증 및 인증 백엔드로 활용하여 사용자 로그인을 지원하게 됩니다.
-            </p>
+    <p>
+      Unity SDK에서 사용자의 지갑을 ID에 연결하여 게임에서 이더리움 주소를 가져올 수 있게 하는 이유는 수신 콜백을 등록하고 연결된 코드를 표시하기 위함입니다.
+      그런 다음 사용자는 엔진 지갑에 이 코드를 입력하면 콜백 기능이 실행됩니다. 코드는 <a href="doxygen/class_enjin_s_d_k_1_1_enjin.html#abd0ebc7f68d479d83a8d365c52d35993" target="_blank">Enjin.VerifyLogin(string username, string password)</a>
+      혹은 <a href="doxygen/class_enjin_s_d_k_1_1_enjin.html#ad3766c8ed4e8fdb68f065177d4046027" target="_blank">CreateUser(string username, string email, string password, string role)</a>과 같은 방법으로 반환되는 사용자 개체 아래의 해당 ID의
+      "link_code" 필드에서 검색할 수 있습니다. ID가 이미 연결된 경우 "link_code" 필드는 비워지고 대신 "ethereum_address"가 나타납니다.
+    </p>
 
-            <section class="example">
-              <p>
-                클라우드 플랫폼에서 새 사용자를 만들려면 이름, 비밀번호, 고유 이메일 및 역할을 지정해야 합니다. 모든 필트는 텍스트 문자열로 지정되며 역할은 클라우드 플랫폼에 알려진 기존 값과 일치합니다. 사용자는 발신자가 관리인이 지정된 응용프로그램 내에 만들어집니다. 이렇게 하기 위한 GraphQL 쿼리는 다음과 같습니다:
-              </p>
+    <p>
+          Unity SDK의 <a href="doxygen/class_enjin_s_d_k_1_1_enjin.html#a5935d76a851168b2b5c5a15f0bef753e" target="_blank">Enjin.ListenForLink(int identityID, System.Action&lt;RequestEvent&gt; listener)</a> 의 예로
+          "identityId"는 개발자로서 연결하기 위해 청취하고자 하는 사용자 아래의 특정 ID의 식별자입니다. 즉, 플레이어에게 표시해야 하는 코드가 포함된 ID입니다.
+          "linkingData" 매개 변수는 <a href="doxygen/class_enjin_s_d_k_1_1_request_event.html" target="_blank">RequestEvent</a> 유형의 개체이며, 링크할 때 유용한 메타데이터가 포함되어 있습니다.
+    </p>
 
-              <p>
-                클라우드 플랫폼에 대한 일부 호출에는 작동 할 특정 App을 지정해야합니다. 이것은 그러한 호출입니다. 앱은 'Authorization' 헤더에서 클라우드 플랫폼으로 보낼 때
-                액세스 토큰 앞에 "@" 식별자를 붙이면 지정됩니다. 특정 응용 프로그램에서 작동하기 위한 전체 액세스 토큰은 “App ID"@ "액세스 토큰”으로 보입니다.
-                "액세스 자격 증명 얻기"호출에 대한 응답으로 App 식별자를 "app_id"필드로 찾을 수 있습니다.
-              </p>
-
-              <input id="appId" type="text" name="appId" placeholder="App ID">
-
-              <pre><code class="query-display language-graphql">mutation createUser($name: String!, $password: String!, $email: String!, $role: String!) {
-  user: CreateEnjinUser(name: $name, password: $password, email: $email, role: $role) {
-    id
-    name
-    email
-    roles {
-      id
-      name
-      permissions {
-        id
-        name
-      }
-    }
-    identities {
-      id
-      ethereum_address
-      linking_code
-      updated_at
-      created_at
-      fields {
-        key
-        value
-        searchable
-        displayable
-        unique
-      }
-    }
-    access_tokens
-    created_at
-    updated_at
-  }
-}</code></pre>
-
-              <p>
-                ‘Submit Query’ 버튼을 누르면 위에 있는 쿼리가 아래에 추가된 파라미터와 함께 클라우드 플랫폼 엔드 포인트에 POST됩니다:
-              </p>
-
-              <form method="post">
-                <input class="parameter" type="text" name="name" placeholder="Name">
-                <br>
-                <input class="parameter" type="text" name="password" placeholder="Password">
-                <br>
-                <input class="parameter" type="text" name="email" placeholder="Email">
-                <br>
-                <input class="parameter" type="text" name="role" placeholder="Role">
-
-                <pre><code class="parameter-display language-json">{}</code></pre>
-
-                <button class="v-btn primary" type="submit">Submit Query</button>
-              </form>
-
-              <p>
-                다음은 클라우드 플랫폼에 출력된 응답입니다:
-              </p>
-
-              <pre><code class="output-display language-json">{}</code></pre>
-
-              <p>
-                이 예제 쿼리에서 클라우드 플랫폼에 새로운 사용자를 생성했습니다. 이 콜이 성공하려면 호출자가 자신의 앱에서 사용자를 생성할 수 있는 권한이 있어야 합니다. 일반적으로 이 작업은 호출자에게 관리자 혹은 플랫폼 소유자 역할을 부여하여 수행합니다. 이 새로운 사용자는 호출자의 앱에 대해 하나의 ID로 자동 생성됩니다. Unity SDK에서 이를 실행하기 위한 GraphQL 호출은 <a href="doxygen/class_enjin_s_d_k_1_1_enjin.html#ad3766c8ed4e8fdb68f065177d4046027" target="_blank">CreateUser(string username, string email, string password, string role)</a> 입니다. 이 함수는 새로운 ID가 담긴 새로운 사용자를 생성하고 플레이어의 지갑에 연결할 수 있도록 합니다.
-              </p>
-            -->
-              <p>
-                Unity SDK에서 사용자의 지갑을 ID에 연결하여 게임에서 이더리움 주소를 가져올 수 있게 하는 이유는 수신 콜백을 등록하고 연결된 코드를 표시하기 위함입니다.
-                그런 다음 사용자는 엔진 지갑에 이 코드를 입력하면 콜백 기능이 실행됩니다. 코드는 <a href="doxygen/class_enjin_s_d_k_1_1_enjin.html#abd0ebc7f68d479d83a8d365c52d35993" target="_blank">Enjin.VerifyLogin(string username, string password)</a>
-                혹은 <a href="doxygen/class_enjin_s_d_k_1_1_enjin.html#ad3766c8ed4e8fdb68f065177d4046027" target="_blank">CreateUser(string username, string email, string password, string role)</a>과 같은 방법으로 반환되는 사용자 개체 아래의 해당 ID의
-                "link_code" 필드에서 검색할 수 있습니다. ID가 이미 연결된 경우 "link_code" 필드는 비워지고 대신 "ethereum_address"가 나타납니다.
-              </p>
-
-              <p>
-                    Unity SDK의 <a href="doxygen/class_enjin_s_d_k_1_1_enjin.html#a5935d76a851168b2b5c5a15f0bef753e" target="_blank">Enjin.ListenForLink(int identityID, System.Action&lt;RequestEvent&gt; listener)</a> 의 예로
-                    "identityId"는 개발자로서 연결하기 위해 청취하고자 하는 사용자 아래의 특정 ID의 식별자입니다. 즉, 플레이어에게 표시해야 하는 코드가 포함된 ID입니다.
-                    "linkingData" 매개 변수는 <a href="doxygen/class_enjin_s_d_k_1_1_request_event.html" target="_blank">RequestEvent</a> 유형의 개체이며, 링크할 때 유용한 메타데이터가 포함되어 있습니다.
-              </p>
-
-              <pre><code class="output-display language-javascript">Enjin.ListenForLink(identityId, linkingData => {
+    <pre><code class="output-display language-javascript">Enjin.ListenForLink(identityId, linkingData => {
   Debug.Log("Linked!");
 });</code></pre>
-	</section>
   </div>
 </article>

--- a/ko/live_query/snippets/melting.html
+++ b/ko/live_query/snippets/melting.html
@@ -24,37 +24,7 @@
             이 값은 사용할 앱 ID 입니다. “액세스 자격 증명 얻기” 호출에 대한 응답으로 받은 “app_id” 필드에서 잠재적 App 식별자를 찾을 수 있습니다.
             </p>
 
-            <!--input id="appId" type="text" name="appId" placeholder="App ID"-->
-
-            <pre><code class="query-display language-graphql">mutation meltToken($identityId: Int!, $tokenId: String!, $value: Int!) {
-  request: CreateEnjinRequest(type: MELT, identity_id: $identityId, melt_token_data: { token_id: $tokenId, value: $value }) {
-    id
-    encoded_data
-    state
-  }
-}</code></pre>
-
-            <p>
-                ‘Submit Query’ 버튼을 누르면 위에 있는 쿼리가 아래에 추가된 파라미터와 함께 클라우드 플랫폼 엔드 포인트에 POST됩니다:
-            </p>
-
-            <form method="post">
-                <input class="parameter" type="text" name="identityId" placeholder="Sender Identity ID">
-                <br>
-                <input class="parameter" type="text" name="tokenId" placeholder="Item ID">
-                <br>
-                <input class="parameter" type="text" name="value" placeholder="Amount to Melt">
-
-                <pre><code class="parameter-display language-json">{}</code></pre>
-
-                <button class="v-btn primary" type="submit">Submit Query</button>
-            </form>
-
-            <p>
-                    다음은 클라우드 플랫폼에 출력된 응답입니다:
-            </p>
-
-            <pre><code class="output-display language-json">{}</code></pre>
+            {{ MeltTokenExample }}
 
             <p>
                     이 예제 쿼리에서는 발신자가 엔진 지갑을 사용하여 수락하거나 거부할 수 있는 멜팅 요청을 발행했습니다. Unity SDK에서 이를 실행하기 위한 GraphQL 호출은

--- a/ko/live_query/snippets/sending_an_item_to_a_user.html
+++ b/ko/live_query/snippets/sending_an_item_to_a_user.html
@@ -26,39 +26,7 @@
             이 값은 사용할 앱 ID 입니다. “액세스 자격 증명 얻기” 호출에 대한 응답으로 받은 “app_id” 필드에서 잠재적 App 식별자를 찾을 수 있습니다.
             </p>
 
-            <!--input id="appId" type="text" name="appId" placeholder="App ID"-->
-
-            <pre><code class="query-display language-graphql">mutation sendItem($identityId: Int!, $recipientIdentityId: Int!, $tokenId: String!, $value: Int!) {
-  CreateEnjinRequest(type: SEND, identity_id: $identityId, send_token_data: { recipient_identity_id: $recipientIdentityId, token_id: $tokenId, value: $value }) {
-    id
-    encoded_data
-    state
-  }
-}</code></pre>
-
-            <p>
-                ‘Submit Query’ 버튼을 누르면 위에 있는 쿼리가 아래에 추가된 파라미터와 함께 클라우드 플랫폼 엔드 포인트에 POST됩니다:
-            </p>
-
-            <form method="post">
-                <input class="parameter" type="text" name="identityId" placeholder="Sender Identity ID">
-                <br>
-                <input class="parameter" type="text" name="recipientIdentityId" placeholder="Recipient Identity ID">
-                <br>
-                <input class="parameter" type="text" name="tokenId" placeholder="Item ID">
-                <br>
-                <input class="parameter" type="text" name="value" placeholder="Amount">
-
-                <pre><code class="parameter-display language-json">{}</code></pre>
-
-                <button class="v-btn primary" type="submit">Submit Query</button>
-            </form>
-
-            <p>
-                다음은 클라우드 플랫폼에 출력된 응답입니다:
-            </p>
-
-            <pre><code class="output-display language-json">{}</code></pre>
+            {{ SendItemExample }}
 
             <p>
                 이 예제 쿼리에서는 발신인이 엔진 지갑을 이용하여 수락하거나 거부할 수 있는 아이템 전송 요청을 만들었습니다. 게임 서버가 게임 내 행동을 기반으로 어떤 아이템을

--- a/ko/live_query/snippets/trades.html
+++ b/ko/live_query/snippets/trades.html
@@ -27,43 +27,7 @@
             이 값은 사용할 앱 ID 입니다. “액세스 자격 증명 얻기” 호출에 대한 응답으로 받은 “app_id” 필드에서 잠재적 App 식별자를 찾을 수 있습니다.
             </p>
 
-            <!--input id="appId" type="text" name="appId" placeholder="App ID"-->
-
-            <pre><code class="query-display language-graphql">mutation sendTrade($identityId: Int!, $askingTokenId: String!, $askingValue: Int!, $offeringTokenId: String!, $offeringValue: Int!, $secondPartyIdentityId: Int!) {
-  result: CreateEnjinRequest(identity_id: $identityId, type: CREATE_TRADE, create_trade_data: { asking_tokens: [{ id: $askingTokenId, value: $askingValue }], offering_tokens: [{ id: $offeringTokenId, value: $offeringValue }], second_party_identity_id: $secondPartyIdentityId }) {
-    id
-    encoded_data
-    state
-  }
-}</code></pre>
-
-            <p>
-                ‘Submit Query’ 버튼을 누르면 위에 있는 쿼리가 아래에 추가된 파라미터와 함께 클라우드 플랫폼 엔드 포인트에 POST됩니다:
-            </p>
-
-            <form method="post">
-                <input class="parameter" type="text" name="identityId" placeholder="Sender Identity ID">
-                <br>
-                <input class="parameter" type="text" name="secondPartyIdentityId" placeholder="Second Party Identity ID">
-                <br>
-                <input class="parameter" type="text" name="askingTokenId" placeholder="Asking Item ID">
-                <br>
-                <input class="parameter" type="text" name="askingValue" placeholder="Asking Item Amount">
-                <br>
-                <input class="parameter" type="text" name="offeringTokenId" placeholder="Offering Item ID">
-                <br>
-                <input class="parameter" type="text" name="offeringValue" placeholder="Offering Item Amount">
-
-                <pre><code class="parameter-display language-json">{}</code></pre>
-
-                <button class="v-btn primary" type="submit">Submit Query</button>
-            </form>
-
-            <p>
-                    다음은 클라우드 플랫폼에 출력된 응답입니다:
-            </p>
-
-            <pre><code class="output-display language-json">{}</code></pre>
+            {{ CreateTradeExample }}
 
             <p>
                 이 예제 쿼리에서는 발신자가 엔진 지갑을 사용하여 수락하거나 거부할 수 있는 거래 요청을 만들었습니다. 이것은 게임 서버가 아이템의 교환을 안전하게 처리할 수 있도록 하는 등
@@ -104,35 +68,7 @@
             이 값은 사용할 앱 ID 입니다. “액세스 자격 증명 얻기” 호출에 대한 응답으로 받은 “app_id” 필드에서 잠재적 App 식별자를 찾을 수 있습니다.
             </p>
 
-            <!--input id="appId" type="text" name="appId" placeholder="App ID"-->
-
-            <pre><code class="query-display language-graphql">mutation sendTrade($identityId: Int!, $tradeId: String!) {
-  result: CreateEnjinRequest(identity_id: $identityId, type: COMPLETE_TRADE, complete_trade_data: { trade_id: $tradeId }) {
-    id
-    encoded_data
-    state
-  }
-}</code></pre>
-
-            <p>
-                ‘Submit Query’ 버튼을 누르면 위에 있는 쿼리가 아래에 추가된 파라미터와 함께 클라우드 플랫폼 엔드 포인트에 POST됩니다:
-            </p>
-
-            <form method="post">
-                <input class="parameter" type="text" name="identityId" placeholder="Sender Identity ID">
-                <br>
-                <input class="parameter" type="text" name="tradeId" placeholder="Trade ID">
-
-                <pre><code class="parameter-display language-json">{}</code></pre>
-
-                <button class="v-btn primary" type="submit">Submit Query</button>
-            </form>
-
-            <p>
-                다음은 클라우드 플랫폼에 출력된 응답입니다:
-            </p>
-
-            <pre><code class="output-display language-json">{}</code></pre>
+            {{ CompleteTradeExample }}
 
             <p>
                     이 예제 쿼리에서는 발신자가 엔진 지갑을 사용하여 제안된 거래를 수락하거나 거부할 수 있도록 거래 완료 요청을 발행했습니다.

--- a/live_query/snippets/access_credentials.html
+++ b/live_query/snippets/access_credentials.html
@@ -1,4 +1,3 @@
-<!-- Getting Access Credentials -->
 <article class="live-query">
     <h1>
         Getting Access Credentials
@@ -20,41 +19,7 @@
                 Logging a User into a Cloud Platform requires their email address and password. The GraphQL query to do so is as follows:
             </p>
 
-            <pre><code class="query-display language-graphql">query login($email:String!, $password:String!) {
-  results: EnjinOauth(email: $email, password: $password) {
-    id
-    access_tokens
-    roles {
-      name
-    }
-    identities {
-      id
-      app_id
-      ethereum_address
-    }
-  }
-}</code></pre>
-
-            <p>
-                Pressing the 'Submit Query' button will POST the query above to the Cloud Platform endpoint, along with additional parameters encoded
-                as follows:
-            </p>
-
-            <form method="post">
-                <input class="parameter" type="text" name="email" placeholder="Email">
-                <br>
-                <input class="parameter" type="text" name="password" placeholder="Password">
-
-                <pre><code class="parameter-display language-json">{}</code></pre>
-
-                <button class="v-btn primary" type="submit">Submit Query</button>
-            </form>
-
-            <p>
-                Here is the output response from the Cloud Platform:
-            </p>
-
-            <pre><code class="output-display language-json">{}</code></pre>
+            {{ LoginExample }}
 
             <p>
                 In the Unity SDK, functionality identical to this call is implemented by the <a

--- a/live_query/snippets/creating_a_new_user.html
+++ b/live_query/snippets/creating_a_new_user.html
@@ -1,4 +1,3 @@
-<!-- Creating a New User -->
 <article class="live-query">
     <h1>
         Creating a New User
@@ -29,65 +28,7 @@
             "Getting Access Credentials" call.
             </p>
 
-            <!--input id="appId" type="text" name="appId" placeholder="App ID"-->
-
-            <pre><code class="query-display language-graphql">mutation createUser($name: String!, $password: String!, $email: String!, $role: String!) {
-  user: CreateEnjinUser(name: $name, password: $password, email: $email, role: $role) {
-    id
-    name
-    email
-    roles {
-      id
-      name
-      permissions {
-        id
-        name
-      }
-    }
-    identities {
-      id
-      ethereum_address
-      linking_code
-      updated_at
-      created_at
-      fields {
-        key
-        value
-        searchable
-        displayable
-        unique
-      }
-    }
-    access_tokens
-    created_at
-    updated_at
-  }
-}</code></pre>
-
-            <p>
-                Pressing the 'Submit Query' button will POST the query above to the Cloud Platform endpoint, along with additional parameters encoded
-                as follows:
-            </p>
-
-            <form method="post">
-                <input class="parameter" type="text" name="name" placeholder="Name">
-                <br>
-                <input class="parameter" type="text" name="password" placeholder="Password">
-                <br>
-                <input class="parameter" type="text" name="email" placeholder="Email">
-                <br>
-                <input class="parameter" type="text" name="role" placeholder="Role" value="Player">
-
-                <pre><code class="parameter-display language-json">{}</code></pre>
-
-                <button class="v-btn primary" type="submit">Submit Query</button>
-            </form>
-
-            <p>
-                Here is the output response from the Cloud Platform:
-            </p>
-
-            <pre><code class="output-display language-json">{}</code></pre>
+            {{ CreateUserExample }}
 
             <p>
                 In this example query, we have created a new User on the Cloud Platform. In order for this call to succeed, the caller must have

--- a/live_query/snippets/getting_a_users_items.html
+++ b/live_query/snippets/getting_a_users_items.html
@@ -19,52 +19,7 @@
                 as follows:
             </p>
 
-            <pre><code class="query-display language-graphql">query getAllItems($identityId: Int!) {
-  result: EnjinIdentities(id: $identityId) {
-    tokens(include_creator_tokens: true) {
-        app_id
-        index
-        token_id
-        name
-        creator
-        totalSupply
-        reserve
-        circulatingSupply
-        supplyModel
-        meltValue
-        meltFeeRatio
-        meltFeeMaxRatio
-        transferable
-        transferFeeSettings {
-          type
-          token_id
-          value
-        }
-        nonFungible
-        icon
-        isCreator
-    }
-  }
-}</code></pre>
-
-            <p>
-                Pressing the 'Submit Query' button will POST the query above to the Cloud Platform endpoint, along with additional parameters encoded
-                as follows:
-            </p>
-
-            <form method="post">
-                <input class="parameter" type="text" name="identityId" placeholder="Identity ID">
-
-                <pre><code class="parameter-display language-json">{}</code></pre>
-
-                <button class="v-btn primary" type="submit">Submit Query</button>
-            </form>
-
-            <p>
-                Here is the output response from the Cloud Platform:
-            </p>
-
-            <pre><code class="output-display language-json">{}</code></pre>
+            {{ ItemsExample }}
 
             <p>
                 In this example query, we have retrieved the first page of a User's inventory from the Cloud Platform. Please note that the "page"
@@ -75,4 +30,3 @@
         </section>
     </div>
 </article>
-

--- a/live_query/snippets/linking_a_wallet.html
+++ b/live_query/snippets/linking_a_wallet.html
@@ -1,100 +1,22 @@
 <!-- Linking a Wallet -->
 <article class="live-query">
   <h1>
-	Linking a Wallet
+	 Linking a Wallet
   </h1>
   <summary>
-	Newly-created Identities include codes that players can enter in the Enjin Wallet to link an Ethereum address for handling Items.
+	 Newly-created Identities include codes that players can enter in the Enjin Wallet to link an Ethereum address for handling Items.
   </summary>
   <div>
-                      <!--
-            <p>
-              This method, given an Admin's access token, will send a request to the Cloud Platform which creates a new User and Identity with the specified details. This Identity will need to be linked at some point to a Player's wallet using the Enjin Wallet App before it can be particularly useful. The use case for this sort of User crreation is to let game developers leverage the Cloud Platform as a kind of authorization and credentials backend in supporting User login.
-            </p>
+    <p>
+      In the Unity SDK, the intended workflow for linking a User's wallet to an Identity such that your game might retrieve their Ethereum address is to register a listening callback and display a linking code. The User will then enter this code in their Enjin Wallet, at which time your callback function will be triggered. The code can be retrieved from the "linking_code" field of the appropriate Identity under the User object returned from methods such as <a href="doxygen/class_enjin_s_d_k_1_1_enjin.html#abd0ebc7f68d479d83a8d365c52d35993" target="_blank">Enjin.VerifyLogin(string username, string password)</a> or <a href="doxygen/class_enjin_s_d_k_1_1_enjin.html#ad3766c8ed4e8fdb68f065177d4046027" target="_blank">CreateUser(string username, string email, string password, string role)</a>. If the Identity has already been linked, then the "linking_code" field will be null and an "ethereum_address" will be present.
+    </p>
 
-            <section class="example">
-              <p>
-                Creating a new User on the Cloud Platform requires specifying a name, password, unique email, and role. All fields are specified as text strings, with the Role matching an existing value known to the Cloud Platform. The User is created under the specified App that the caller is an Admin of. The GraphQL query to do so is as follows:
-              </p>
+    <p>
+      An example of the Unity SDK's <a href="doxygen/class_enjin_s_d_k_1_1_enjin.html#a5935d76a851168b2b5c5a15f0bef753e" target="_blank">Enjin.ListenForLink(int identityID, System.Action&lt;RequestEvent&gt; listener)</a> where "identityId" is the identifier of a specific Identity under a User which you as developer would like to listen for linking on. That is, this is the Identity containing the code which you should be displaying to the player. The "linkingData" parameter is an object of type <a href="doxygen/class_enjin_s_d_k_1_1_request_event.html" target="_blank">RequestEvent</a> and includes some potentially-useful metadata about the linking event.
+    </p>
 
-              <p>
-                Some calls to the Cloud Platform require specifying a particular App to operate on. This is one such call. The App is specified by prepending its identifier with an "@" to the front of the access token when sending that in the 'Authorization' header to the Cloud Platform. That is, the entire access token for operating on a specific App will look like "App ID"@"access token"; you can find potential App identifiers as the "app_id" field in the response to the "Getting Access Credentials" call.
-              </p>
-
-              <input id="appId" type="text" name="appId" placeholder="App ID">
-
-              <pre><code class="query-display language-graphql">mutation createUser($name: String!, $password: String!, $email: String!, $role: String!) {
-  user: CreateEnjinUser(name: $name, password: $password, email: $email, role: $role) {
-    id
-    name
-    email
-    roles {
-      id
-      name
-      permissions {
-        id
-        name
-      }
-    }
-    identities {
-      id
-      ethereum_address
-      linking_code
-      updated_at
-      created_at
-      fields {
-        key
-        value
-        searchable
-        displayable
-        unique
-      }
-    }
-    access_tokens
-    created_at
-    updated_at
-  }
-}</code></pre>
-
-              <p>
-                Pressing the 'Submit Query' button will POST the query above to the Cloud Platform endpoint, along with additional parameters encoded as follows:
-              </p>
-
-              <form method="post">
-                <input class="parameter" type="text" name="name" placeholder="Name">
-                <br>
-                <input class="parameter" type="text" name="password" placeholder="Password">
-                <br>
-                <input class="parameter" type="text" name="email" placeholder="Email">
-                <br>
-                <input class="parameter" type="text" name="role" placeholder="Role">
-
-                <pre><code class="parameter-display language-json">{}</code></pre>
-
-                <button class="v-btn primary" type="submit">Submit Query</button>
-              </form>
-
-              <p>
-                Here is the output response from the Cloud Platform:
-              </p>
-
-              <pre><code class="output-display language-json">{}</code></pre>
-
-              <p>
-                In this example query, we have created a new User on the Cloud Platform. In order for this call to succeed, the caller must have permissions to create Users on their App. Typically, this is done by letting the caller have the Admin or Platform Owner Roles. This new User is automatically created with a single Identity for the caller's App. The corresponding function in the Unity SDK to this GraphQL call is <a href="doxygen/class_enjin_s_d_k_1_1_enjin.html#ad3766c8ed4e8fdb68f065177d4046027" target="_blank">CreateUser(string username, string email, string password, string role)</a> which will create a new User with new Identity and return it such that we might link it to a Player's wallet.
-              </p>
-            -->
-              <p>
-                In the Unity SDK, the intended workflow for linking a User's wallet to an Identity such that your game might retrieve their Ethereum address is to register a listening callback and display a linking code. The User will then enter this code in their Enjin Wallet, at which time your callback function will be triggered. The code can be retrieved from the "linking_code" field of the appropriate Identity under the User object returned from methods such as <a href="doxygen/class_enjin_s_d_k_1_1_enjin.html#abd0ebc7f68d479d83a8d365c52d35993" target="_blank">Enjin.VerifyLogin(string username, string password)</a> or <a href="doxygen/class_enjin_s_d_k_1_1_enjin.html#ad3766c8ed4e8fdb68f065177d4046027" target="_blank">CreateUser(string username, string email, string password, string role)</a>. If the Identity has already been linked, then the "linking_code" field will be null and an "ethereum_address" will be present.
-              </p>
-
-              <p>
-                An example of the Unity SDK's <a href="doxygen/class_enjin_s_d_k_1_1_enjin.html#a5935d76a851168b2b5c5a15f0bef753e" target="_blank">Enjin.ListenForLink(int identityID, System.Action&lt;RequestEvent&gt; listener)</a> where "identityId" is the identifier of a specific Identity under a User which you as developer would like to listen for linking on. That is, this is the Identity containing the code which you should be displaying to the player. The "linkingData" parameter is an object of type <a href="doxygen/class_enjin_s_d_k_1_1_request_event.html" target="_blank">RequestEvent</a> and includes some potentially-useful metadata about the linking event.
-              </p>
-
-              <pre><code class="output-display language-javascript">Enjin.ListenForLink(identityId, linkingData => {
+    <pre><code class="output-display language-javascript">Enjin.ListenForLink(identityId, linkingData => {
   Debug.Log("Linked!");
 });</code></pre>
-	</section>
   </div>
 </article>

--- a/live_query/snippets/melting.html
+++ b/live_query/snippets/melting.html
@@ -30,38 +30,7 @@
             "Getting Access Credentials" call.
             </p>
 
-            <!--input id="appId" type="text" name="appId" placeholder="App ID"-->
-
-            <pre><code class="query-display language-graphql">mutation meltToken($identityId: Int!, $tokenId: String!, $value: Int!) {
-  request: CreateEnjinRequest(type: MELT, identity_id: $identityId, melt_token_data: { token_id: $tokenId, value: $value }) {
-    id
-    encoded_data
-    state
-  }
-}</code></pre>
-
-            <p>
-                Pressing the 'Submit Query' button will POST the query above to the Cloud Platform endpoint, along with additional parameters encoded
-                as follows:
-            </p>
-
-            <form method="post">
-                <input class="parameter" type="text" name="identityId" placeholder="Sender Identity ID">
-                <br>
-                <input class="parameter" type="text" name="tokenId" placeholder="Item ID">
-                <br>
-                <input class="parameter" type="text" name="value" placeholder="Amount to Melt">
-
-                <pre><code class="parameter-display language-json">{}</code></pre>
-
-                <button class="v-btn primary" type="submit">Submit Query</button>
-            </form>
-
-            <p>
-                Here is the output response from the Cloud Platform:
-            </p>
-
-            <pre><code class="output-display language-json">{}</code></pre>
+            {{ MeltTokenExample }}
 
             <p>
                 In this example query, we have issued a melt request for the sender to either accept or deny using their Enjin Wallet. The

--- a/live_query/snippets/sending_an_item_to_a_user.html
+++ b/live_query/snippets/sending_an_item_to_a_user.html
@@ -31,40 +31,7 @@
             "Getting Access Credentials" call.
             </p>
 
-            <!--input id="appId" type="text" name="appId" placeholder="App ID"-->
-
-            <pre><code class="query-display language-graphql">mutation sendItem($identityId: Int!, $recipientIdentityId: Int!, $tokenId: String!, $value: Int!) {
-  CreateEnjinRequest(type: SEND, identity_id: $identityId, send_token_data: { recipient_identity_id: $recipientIdentityId, token_id: $tokenId, value: $value }) {
-    id
-    encoded_data
-    state
-  }
-}</code></pre>
-
-            <p>
-                Pressing the 'Submit Query' button will POST the query above to the Cloud Platform endpoint, along with additional parameters encoded
-                as follows:
-            </p>
-
-            <form method="post">
-                <input class="parameter" type="text" name="identityId" placeholder="Sender Identity ID">
-                <br>
-                <input class="parameter" type="text" name="recipientIdentityId" placeholder="Recipient Identity ID">
-                <br>
-                <input class="parameter" type="text" name="tokenId" placeholder="Item ID">
-                <br>
-                <input class="parameter" type="text" name="value" placeholder="Amount">
-
-                <pre><code class="parameter-display language-json">{}</code></pre>
-
-                <button class="v-btn primary" type="submit">Submit Query</button>
-            </form>
-
-            <p>
-                Here is the output response from the Cloud Platform:
-            </p>
-
-            <pre><code class="output-display language-json">{}</code></pre>
+            {{ SendItemExample }}
 
             <p>
                 In this example query, we have created an Item transfer request for the sender to either accept or deny using their Enjin Wallet. This

--- a/live_query/snippets/trades.html
+++ b/live_query/snippets/trades.html
@@ -33,44 +33,7 @@
             "Getting Access Credentials" call.
             </p>
 
-            <!--input id="appId" type="text" name="appId" placeholder="App ID"-->
-
-            <pre><code class="query-display language-graphql">mutation sendTrade($identityId: Int!, $askingTokenId: String!, $askingValue: Int!, $offeringTokenId: String!, $offeringValue: Int!, $secondPartyIdentityId: Int!) {
-  result: CreateEnjinRequest(identity_id: $identityId, type: CREATE_TRADE, create_trade_data: { asking_tokens: [{ id: $askingTokenId, value: $askingValue }], offering_tokens: [{ id: $offeringTokenId, value: $offeringValue }], second_party_identity_id: $secondPartyIdentityId }) {
-    id
-    encoded_data
-    state
-  }
-}</code></pre>
-
-            <p>
-                Pressing the 'Submit Query' button will POST the query above to the Cloud Platform endpoint, along with additional parameters encoded
-                as follows:
-            </p>
-
-            <form method="post">
-                <input class="parameter" type="text" name="identityId" placeholder="Sender Identity ID">
-                <br>
-                <input class="parameter" type="text" name="secondPartyIdentityId" placeholder="Second Party Identity ID">
-                <br>
-                <input class="parameter" type="text" name="askingTokenId" placeholder="Asking Item ID">
-                <br>
-                <input class="parameter" type="text" name="askingValue" placeholder="Asking Item Amount">
-                <br>
-                <input class="parameter" type="text" name="offeringTokenId" placeholder="Offering Item ID">
-                <br>
-                <input class="parameter" type="text" name="offeringValue" placeholder="Offering Item Amount">
-
-                <pre><code class="parameter-display language-json">{}</code></pre>
-
-                <button class="v-btn primary" type="submit">Submit Query</button>
-            </form>
-
-            <p>
-                Here is the output response from the Cloud Platform:
-            </p>
-
-            <pre><code class="output-display language-json">{}</code></pre>
+            {{ CreateTradeExample }}
 
             <p>
                 In this example query, we have created a trade request for the sender to either accept or deny using their Enjin Wallet. This has a
@@ -120,36 +83,7 @@
             "Getting Access Credentials" call.
             </p>
 
-            <!--input id="appId" type="text" name="appId" placeholder="App ID"-->
-
-            <pre><code class="query-display language-graphql">mutation sendTrade($identityId: Int!, $tradeId: String!) {
-  result: CreateEnjinRequest(identity_id: $identityId, type: COMPLETE_TRADE, complete_trade_data: { trade_id: $tradeId }) {
-    id
-    encoded_data
-    state
-  }
-}</code></pre>
-
-            <p>
-                Pressing the 'Submit Query' button will POST the query above to the Cloud Platform endpoint, along with additional parameters encoded
-                as follows:
-            </p>
-
-            <form method="post">
-                <input class="parameter" type="text" name="identityId" placeholder="Sender Identity ID">
-                <br>
-                <input class="parameter" type="text" name="tradeId" placeholder="Trade ID">
-
-                <pre><code class="parameter-display language-json">{}</code></pre>
-
-                <button class="v-btn primary" type="submit">Submit Query</button>
-            </form>
-
-            <p>
-                Here is the output response from the Cloud Platform:
-            </p>
-
-            <pre><code class="output-display language-json">{}</code></pre>
+            {{ CompleteTradeExample }}
 
             <p>
                 In this example query, we have issued a trade completion request for the sender to either accept or deny a proposed trade using their


### PR DESCRIPTION
Swaps out Livequery UIs for placeholders, the markup of these needs to match what TP expects, and is pretty boilerplate anyway - repeating the blocks for each locale also doesn't scale easily.

This moves the example UI rendition into TP which also means these needn't be html anymore, we could convert these into markdown and it'll match the rest of the docs.